### PR TITLE
Fix leader election not working issue

### DIFF
--- a/riteraft/message.py
+++ b/riteraft/message.py
@@ -31,8 +31,9 @@ class RaftRespJoinSuccess(Encoder):
 
 
 class RaftRespIdReserved(Encoder):
-    def __init__(self, id: int):
+    def __init__(self, id: int, peer_addrs: Dict[int, str]):
         self.id = id
+        self.peer_addrs = peer_addrs
 
     @classmethod
     def decode(cls, data: bytes) -> "RaftRespIdReserved":

--- a/riteraft/message.py
+++ b/riteraft/message.py
@@ -31,8 +31,9 @@ class RaftRespJoinSuccess(Encoder):
 
 
 class RaftRespIdReserved(Encoder):
-    def __init__(self, id: int, peer_addrs: Dict[int, str]):
-        self.id = id
+    def __init__(self, leader_id: int, reserved_id: int, peer_addrs: Dict[int, str]):
+        self.leader_id = leader_id
+        self.reserved_id = reserved_id
         self.peer_addrs = peer_addrs
 
     @classmethod

--- a/riteraft/message.py
+++ b/riteraft/message.py
@@ -89,7 +89,8 @@ class MessageConfigChange(Encoder):
 
 
 class MessageRequestId(Encoder):
-    def __init__(self, chan: Queue):
+    def __init__(self, addr: str, chan: Queue):
+        self.addr = addr
         self.chan = chan
 
     @classmethod

--- a/riteraft/protos/eraftpb_pb2.pyi
+++ b/riteraft/protos/eraftpb_pb2.pyi
@@ -9,46 +9,245 @@ from google.protobuf import message as _message
 from google.protobuf.internal import containers as _containers
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 
-AddLearnerNode: ConfChangeType
-AddNode: ConfChangeType
-Auto: ConfChangeTransition
 DESCRIPTOR: _descriptor.FileDescriptor
+
+class EntryType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = []
+    EntryNormal: _ClassVar[EntryType]
+    EntryConfChange: _ClassVar[EntryType]
+    EntryConfChangeV2: _ClassVar[EntryType]
+
+class MessageType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = []
+    MsgHup: _ClassVar[MessageType]
+    MsgBeat: _ClassVar[MessageType]
+    MsgPropose: _ClassVar[MessageType]
+    MsgAppend: _ClassVar[MessageType]
+    MsgAppendResponse: _ClassVar[MessageType]
+    MsgRequestVote: _ClassVar[MessageType]
+    MsgRequestVoteResponse: _ClassVar[MessageType]
+    MsgSnapshot: _ClassVar[MessageType]
+    MsgHeartbeat: _ClassVar[MessageType]
+    MsgHeartbeatResponse: _ClassVar[MessageType]
+    MsgUnreachable: _ClassVar[MessageType]
+    MsgSnapStatus: _ClassVar[MessageType]
+    MsgCheckQuorum: _ClassVar[MessageType]
+    MsgTransferLeader: _ClassVar[MessageType]
+    MsgTimeoutNow: _ClassVar[MessageType]
+    MsgReadIndex: _ClassVar[MessageType]
+    MsgReadIndexResp: _ClassVar[MessageType]
+    MsgRequestPreVote: _ClassVar[MessageType]
+    MsgRequestPreVoteResponse: _ClassVar[MessageType]
+
+class ConfChangeTransition(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = []
+    Auto: _ClassVar[ConfChangeTransition]
+    Implicit: _ClassVar[ConfChangeTransition]
+    Explicit: _ClassVar[ConfChangeTransition]
+
+class ConfChangeType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = []
+    AddNode: _ClassVar[ConfChangeType]
+    AddLearnerNode: _ClassVar[ConfChangeType]
+    RemoveNode: _ClassVar[ConfChangeType]
+
+EntryNormal: EntryType
 EntryConfChange: EntryType
 EntryConfChangeV2: EntryType
-EntryNormal: EntryType
-Explicit: ConfChangeTransition
-Implicit: ConfChangeTransition
+MsgHup: MessageType
+MsgBeat: MessageType
+MsgPropose: MessageType
 MsgAppend: MessageType
 MsgAppendResponse: MessageType
-MsgBeat: MessageType
-MsgCheckQuorum: MessageType
+MsgRequestVote: MessageType
+MsgRequestVoteResponse: MessageType
+MsgSnapshot: MessageType
 MsgHeartbeat: MessageType
 MsgHeartbeatResponse: MessageType
-MsgHup: MessageType
-MsgPropose: MessageType
+MsgUnreachable: MessageType
+MsgSnapStatus: MessageType
+MsgCheckQuorum: MessageType
+MsgTransferLeader: MessageType
+MsgTimeoutNow: MessageType
 MsgReadIndex: MessageType
 MsgReadIndexResp: MessageType
 MsgRequestPreVote: MessageType
 MsgRequestPreVoteResponse: MessageType
-MsgRequestVote: MessageType
-MsgRequestVoteResponse: MessageType
-MsgSnapStatus: MessageType
-MsgSnapshot: MessageType
-MsgTimeoutNow: MessageType
-MsgTransferLeader: MessageType
-MsgUnreachable: MessageType
+Auto: ConfChangeTransition
+Implicit: ConfChangeTransition
+Explicit: ConfChangeTransition
+AddNode: ConfChangeType
+AddLearnerNode: ConfChangeType
 RemoveNode: ConfChangeType
 
+class Entry(_message.Message):
+    __slots__ = ["entry_type", "term", "index", "data", "context", "sync_log"]
+    ENTRY_TYPE_FIELD_NUMBER: _ClassVar[int]
+    TERM_FIELD_NUMBER: _ClassVar[int]
+    INDEX_FIELD_NUMBER: _ClassVar[int]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    CONTEXT_FIELD_NUMBER: _ClassVar[int]
+    SYNC_LOG_FIELD_NUMBER: _ClassVar[int]
+    entry_type: EntryType
+    term: int
+    index: int
+    data: bytes
+    context: bytes
+    sync_log: bool
+    def __init__(
+        self,
+        entry_type: _Optional[_Union[EntryType, str]] = ...,
+        term: _Optional[int] = ...,
+        index: _Optional[int] = ...,
+        data: _Optional[bytes] = ...,
+        context: _Optional[bytes] = ...,
+        sync_log: bool = ...,
+    ) -> None: ...
+
+class SnapshotMetadata(_message.Message):
+    __slots__ = ["conf_state", "index", "term"]
+    CONF_STATE_FIELD_NUMBER: _ClassVar[int]
+    INDEX_FIELD_NUMBER: _ClassVar[int]
+    TERM_FIELD_NUMBER: _ClassVar[int]
+    conf_state: ConfState
+    index: int
+    term: int
+    def __init__(
+        self,
+        conf_state: _Optional[_Union[ConfState, _Mapping]] = ...,
+        index: _Optional[int] = ...,
+        term: _Optional[int] = ...,
+    ) -> None: ...
+
+class Snapshot(_message.Message):
+    __slots__ = ["data", "metadata"]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    METADATA_FIELD_NUMBER: _ClassVar[int]
+    data: bytes
+    metadata: SnapshotMetadata
+    def __init__(
+        self,
+        data: _Optional[bytes] = ...,
+        metadata: _Optional[_Union[SnapshotMetadata, _Mapping]] = ...,
+    ) -> None: ...
+
+class Message(_message.Message):
+    __slots__ = [
+        "msg_type",
+        "to",
+        "from_",
+        "term",
+        "log_term",
+        "index",
+        "entries",
+        "commit",
+        "commit_term",
+        "snapshot",
+        "request_snapshot",
+        "reject",
+        "reject_hint",
+        "context",
+        "deprecated_priority",
+        "priority",
+    ]
+    MSG_TYPE_FIELD_NUMBER: _ClassVar[int]
+    TO_FIELD_NUMBER: _ClassVar[int]
+    FROM__FIELD_NUMBER: _ClassVar[int]
+    TERM_FIELD_NUMBER: _ClassVar[int]
+    LOG_TERM_FIELD_NUMBER: _ClassVar[int]
+    INDEX_FIELD_NUMBER: _ClassVar[int]
+    ENTRIES_FIELD_NUMBER: _ClassVar[int]
+    COMMIT_FIELD_NUMBER: _ClassVar[int]
+    COMMIT_TERM_FIELD_NUMBER: _ClassVar[int]
+    SNAPSHOT_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_SNAPSHOT_FIELD_NUMBER: _ClassVar[int]
+    REJECT_FIELD_NUMBER: _ClassVar[int]
+    REJECT_HINT_FIELD_NUMBER: _ClassVar[int]
+    CONTEXT_FIELD_NUMBER: _ClassVar[int]
+    DEPRECATED_PRIORITY_FIELD_NUMBER: _ClassVar[int]
+    PRIORITY_FIELD_NUMBER: _ClassVar[int]
+    msg_type: MessageType
+    to: int
+    from_: int
+    term: int
+    log_term: int
+    index: int
+    entries: _containers.RepeatedCompositeFieldContainer[Entry]
+    commit: int
+    commit_term: int
+    snapshot: Snapshot
+    request_snapshot: int
+    reject: bool
+    reject_hint: int
+    context: bytes
+    deprecated_priority: int
+    priority: int
+    def __init__(
+        self,
+        msg_type: _Optional[_Union[MessageType, str]] = ...,
+        to: _Optional[int] = ...,
+        from_: _Optional[int] = ...,
+        term: _Optional[int] = ...,
+        log_term: _Optional[int] = ...,
+        index: _Optional[int] = ...,
+        entries: _Optional[_Iterable[_Union[Entry, _Mapping]]] = ...,
+        commit: _Optional[int] = ...,
+        commit_term: _Optional[int] = ...,
+        snapshot: _Optional[_Union[Snapshot, _Mapping]] = ...,
+        request_snapshot: _Optional[int] = ...,
+        reject: bool = ...,
+        reject_hint: _Optional[int] = ...,
+        context: _Optional[bytes] = ...,
+        deprecated_priority: _Optional[int] = ...,
+        priority: _Optional[int] = ...,
+    ) -> None: ...
+
+class HardState(_message.Message):
+    __slots__ = ["term", "vote", "commit"]
+    TERM_FIELD_NUMBER: _ClassVar[int]
+    VOTE_FIELD_NUMBER: _ClassVar[int]
+    COMMIT_FIELD_NUMBER: _ClassVar[int]
+    term: int
+    vote: int
+    commit: int
+    def __init__(
+        self,
+        term: _Optional[int] = ...,
+        vote: _Optional[int] = ...,
+        commit: _Optional[int] = ...,
+    ) -> None: ...
+
+class ConfState(_message.Message):
+    __slots__ = ["voters", "learners", "voters_outgoing", "learners_next", "auto_leave"]
+    VOTERS_FIELD_NUMBER: _ClassVar[int]
+    LEARNERS_FIELD_NUMBER: _ClassVar[int]
+    VOTERS_OUTGOING_FIELD_NUMBER: _ClassVar[int]
+    LEARNERS_NEXT_FIELD_NUMBER: _ClassVar[int]
+    AUTO_LEAVE_FIELD_NUMBER: _ClassVar[int]
+    voters: _containers.RepeatedScalarFieldContainer[int]
+    learners: _containers.RepeatedScalarFieldContainer[int]
+    voters_outgoing: _containers.RepeatedScalarFieldContainer[int]
+    learners_next: _containers.RepeatedScalarFieldContainer[int]
+    auto_leave: bool
+    def __init__(
+        self,
+        voters: _Optional[_Iterable[int]] = ...,
+        learners: _Optional[_Iterable[int]] = ...,
+        voters_outgoing: _Optional[_Iterable[int]] = ...,
+        learners_next: _Optional[_Iterable[int]] = ...,
+        auto_leave: bool = ...,
+    ) -> None: ...
+
 class ConfChange(_message.Message):
-    __slots__ = ["change_type", "context", "id", "node_id"]
+    __slots__ = ["change_type", "node_id", "context", "id"]
     CHANGE_TYPE_FIELD_NUMBER: _ClassVar[int]
+    NODE_ID_FIELD_NUMBER: _ClassVar[int]
     CONTEXT_FIELD_NUMBER: _ClassVar[int]
     ID_FIELD_NUMBER: _ClassVar[int]
-    NODE_ID_FIELD_NUMBER: _ClassVar[int]
     change_type: ConfChangeType
+    node_id: int
     context: bytes
     id: int
-    node_id: int
     def __init__(
         self,
         change_type: _Optional[_Union[ConfChangeType, str]] = ...,
@@ -70,186 +269,16 @@ class ConfChangeSingle(_message.Message):
     ) -> None: ...
 
 class ConfChangeV2(_message.Message):
-    __slots__ = ["changes", "context", "transition"]
+    __slots__ = ["transition", "changes", "context"]
+    TRANSITION_FIELD_NUMBER: _ClassVar[int]
     CHANGES_FIELD_NUMBER: _ClassVar[int]
     CONTEXT_FIELD_NUMBER: _ClassVar[int]
-    TRANSITION_FIELD_NUMBER: _ClassVar[int]
+    transition: ConfChangeTransition
     changes: _containers.RepeatedCompositeFieldContainer[ConfChangeSingle]
     context: bytes
-    transition: ConfChangeTransition
     def __init__(
         self,
         transition: _Optional[_Union[ConfChangeTransition, str]] = ...,
         changes: _Optional[_Iterable[_Union[ConfChangeSingle, _Mapping]]] = ...,
         context: _Optional[bytes] = ...,
     ) -> None: ...
-
-class ConfState(_message.Message):
-    __slots__ = ["auto_leave", "learners", "learners_next", "voters", "voters_outgoing"]
-    AUTO_LEAVE_FIELD_NUMBER: _ClassVar[int]
-    LEARNERS_FIELD_NUMBER: _ClassVar[int]
-    LEARNERS_NEXT_FIELD_NUMBER: _ClassVar[int]
-    VOTERS_FIELD_NUMBER: _ClassVar[int]
-    VOTERS_OUTGOING_FIELD_NUMBER: _ClassVar[int]
-    auto_leave: bool
-    learners: _containers.RepeatedScalarFieldContainer[int]
-    learners_next: _containers.RepeatedScalarFieldContainer[int]
-    voters: _containers.RepeatedScalarFieldContainer[int]
-    voters_outgoing: _containers.RepeatedScalarFieldContainer[int]
-    def __init__(
-        self,
-        voters: _Optional[_Iterable[int]] = ...,
-        learners: _Optional[_Iterable[int]] = ...,
-        voters_outgoing: _Optional[_Iterable[int]] = ...,
-        learners_next: _Optional[_Iterable[int]] = ...,
-        auto_leave: bool = ...,
-    ) -> None: ...
-
-class Entry(_message.Message):
-    __slots__ = ["context", "data", "entry_type", "index", "sync_log", "term"]
-    CONTEXT_FIELD_NUMBER: _ClassVar[int]
-    DATA_FIELD_NUMBER: _ClassVar[int]
-    ENTRY_TYPE_FIELD_NUMBER: _ClassVar[int]
-    INDEX_FIELD_NUMBER: _ClassVar[int]
-    SYNC_LOG_FIELD_NUMBER: _ClassVar[int]
-    TERM_FIELD_NUMBER: _ClassVar[int]
-    context: bytes
-    data: bytes
-    entry_type: EntryType
-    index: int
-    sync_log: bool
-    term: int
-    def __init__(
-        self,
-        entry_type: _Optional[_Union[EntryType, str]] = ...,
-        term: _Optional[int] = ...,
-        index: _Optional[int] = ...,
-        data: _Optional[bytes] = ...,
-        context: _Optional[bytes] = ...,
-        sync_log: bool = ...,
-    ) -> None: ...
-
-class HardState(_message.Message):
-    __slots__ = ["commit", "term", "vote"]
-    COMMIT_FIELD_NUMBER: _ClassVar[int]
-    TERM_FIELD_NUMBER: _ClassVar[int]
-    VOTE_FIELD_NUMBER: _ClassVar[int]
-    commit: int
-    term: int
-    vote: int
-    def __init__(
-        self,
-        term: _Optional[int] = ...,
-        vote: _Optional[int] = ...,
-        commit: _Optional[int] = ...,
-    ) -> None: ...
-
-class Message(_message.Message):
-    __slots__ = [
-        "commit",
-        "commit_term",
-        "context",
-        "deprecated_priority",
-        "entries",
-        "from_",
-        "index",
-        "log_term",
-        "msg_type",
-        "priority",
-        "reject",
-        "reject_hint",
-        "request_snapshot",
-        "snapshot",
-        "term",
-        "to",
-    ]
-    COMMIT_FIELD_NUMBER: _ClassVar[int]
-    COMMIT_TERM_FIELD_NUMBER: _ClassVar[int]
-    CONTEXT_FIELD_NUMBER: _ClassVar[int]
-    DEPRECATED_PRIORITY_FIELD_NUMBER: _ClassVar[int]
-    ENTRIES_FIELD_NUMBER: _ClassVar[int]
-    FROM__FIELD_NUMBER: _ClassVar[int]
-    INDEX_FIELD_NUMBER: _ClassVar[int]
-    LOG_TERM_FIELD_NUMBER: _ClassVar[int]
-    MSG_TYPE_FIELD_NUMBER: _ClassVar[int]
-    PRIORITY_FIELD_NUMBER: _ClassVar[int]
-    REJECT_FIELD_NUMBER: _ClassVar[int]
-    REJECT_HINT_FIELD_NUMBER: _ClassVar[int]
-    REQUEST_SNAPSHOT_FIELD_NUMBER: _ClassVar[int]
-    SNAPSHOT_FIELD_NUMBER: _ClassVar[int]
-    TERM_FIELD_NUMBER: _ClassVar[int]
-    TO_FIELD_NUMBER: _ClassVar[int]
-    commit: int
-    commit_term: int
-    context: bytes
-    deprecated_priority: int
-    entries: _containers.RepeatedCompositeFieldContainer[Entry]
-    from_: int
-    index: int
-    log_term: int
-    msg_type: MessageType
-    priority: int
-    reject: bool
-    reject_hint: int
-    request_snapshot: int
-    snapshot: Snapshot
-    term: int
-    to: int
-    def __init__(
-        self,
-        msg_type: _Optional[_Union[MessageType, str]] = ...,
-        to: _Optional[int] = ...,
-        from_: _Optional[int] = ...,
-        term: _Optional[int] = ...,
-        log_term: _Optional[int] = ...,
-        index: _Optional[int] = ...,
-        entries: _Optional[_Iterable[_Union[Entry, _Mapping]]] = ...,
-        commit: _Optional[int] = ...,
-        commit_term: _Optional[int] = ...,
-        snapshot: _Optional[_Union[Snapshot, _Mapping]] = ...,
-        request_snapshot: _Optional[int] = ...,
-        reject: bool = ...,
-        reject_hint: _Optional[int] = ...,
-        context: _Optional[bytes] = ...,
-        deprecated_priority: _Optional[int] = ...,
-        priority: _Optional[int] = ...,
-    ) -> None: ...
-
-class Snapshot(_message.Message):
-    __slots__ = ["data", "metadata"]
-    DATA_FIELD_NUMBER: _ClassVar[int]
-    METADATA_FIELD_NUMBER: _ClassVar[int]
-    data: bytes
-    metadata: SnapshotMetadata
-    def __init__(
-        self,
-        data: _Optional[bytes] = ...,
-        metadata: _Optional[_Union[SnapshotMetadata, _Mapping]] = ...,
-    ) -> None: ...
-
-class SnapshotMetadata(_message.Message):
-    __slots__ = ["conf_state", "index", "term"]
-    CONF_STATE_FIELD_NUMBER: _ClassVar[int]
-    INDEX_FIELD_NUMBER: _ClassVar[int]
-    TERM_FIELD_NUMBER: _ClassVar[int]
-    conf_state: ConfState
-    index: int
-    term: int
-    def __init__(
-        self,
-        conf_state: _Optional[_Union[ConfState, _Mapping]] = ...,
-        index: _Optional[int] = ...,
-        term: _Optional[int] = ...,
-    ) -> None: ...
-
-class EntryType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = []
-
-class MessageType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = []
-
-class ConfChangeTransition(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = []
-
-class ConfChangeType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = []

--- a/riteraft/protos/raft_service.proto
+++ b/riteraft/protos/raft_service.proto
@@ -4,7 +4,7 @@ package raftservice;
 import "eraftpb.proto";
 
 service RaftService {
-  rpc RequestId(Empty) returns (IdRequestResponse) {}
+  rpc RequestId(RequestIdArgs) returns (IdRequestResponse) {}
   rpc ChangeConfig(eraftpb.ConfChange) returns (RaftResponse) {}
   rpc SendMessage(eraftpb.Message) returns (RaftResponse) {}
 }
@@ -24,7 +24,9 @@ message IdRequestResponse {
   bytes data = 2;
 }
 
-message Empty {}
+message RequestIdArgs {
+  string addr = 1;
+}
 
 message Entry {
   uint64 key    = 1; 

--- a/riteraft/protos/raft_service_pb2.py
+++ b/riteraft/protos/raft_service_pb2.py
@@ -16,25 +16,25 @@ _sym_db = _symbol_database.Default()
 from . import eraftpb_pb2 as eraftpb__pb2
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x12raft_service.proto\x12\x0braftservice\x1a\reraftpb.proto"\x19\n\x08Proposal\x12\r\n\x05inner\x18\x01 \x01(\x0c"H\n\x11IdRequestResponse\x12%\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x17.raftservice.ResultCode\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c"\x07\n\x05\x45mpty"#\n\x05\x45ntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\t"\x1d\n\x0cRaftResponse\x12\r\n\x05inner\x18\x02 \x01(\x0c*0\n\nResultCode\x12\x06\n\x02Ok\x10\x00\x12\t\n\x05\x45rror\x10\x01\x12\x0f\n\x0bWrongLeader\x10\x02\x32\xd0\x01\n\x0bRaftService\x12\x41\n\tRequestId\x12\x12.raftservice.Empty\x1a\x1e.raftservice.IdRequestResponse"\x00\x12@\n\x0c\x43hangeConfig\x12\x13.eraftpb.ConfChange\x1a\x19.raftservice.RaftResponse"\x00\x12<\n\x0bSendMessage\x12\x10.eraftpb.Message\x1a\x19.raftservice.RaftResponse"\x00\x62\x06proto3'
+    b'\n\x12raft_service.proto\x12\x0braftservice\x1a\reraftpb.proto"\x19\n\x08Proposal\x12\r\n\x05inner\x18\x01 \x01(\x0c"H\n\x11IdRequestResponse\x12%\n\x04\x63ode\x18\x01 \x01(\x0e\x32\x17.raftservice.ResultCode\x12\x0c\n\x04\x64\x61ta\x18\x02 \x01(\x0c"\x1d\n\rRequestIdArgs\x12\x0c\n\x04\x61\x64\x64r\x18\x01 \x01(\t"#\n\x05\x45ntry\x12\x0b\n\x03key\x18\x01 \x01(\x04\x12\r\n\x05value\x18\x02 \x01(\t"\x1d\n\x0cRaftResponse\x12\r\n\x05inner\x18\x02 \x01(\x0c*0\n\nResultCode\x12\x06\n\x02Ok\x10\x00\x12\t\n\x05\x45rror\x10\x01\x12\x0f\n\x0bWrongLeader\x10\x02\x32\xd8\x01\n\x0bRaftService\x12I\n\tRequestId\x12\x1a.raftservice.RequestIdArgs\x1a\x1e.raftservice.IdRequestResponse"\x00\x12@\n\x0c\x43hangeConfig\x12\x13.eraftpb.ConfChange\x1a\x19.raftservice.RaftResponse"\x00\x12<\n\x0bSendMessage\x12\x10.eraftpb.Message\x1a\x19.raftservice.RaftResponse"\x00\x62\x06proto3'
 )
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "raft_service_pb2", globals())
 if _descriptor._USE_C_DESCRIPTORS == False:
     DESCRIPTOR._options = None
-    _RESULTCODE._serialized_start = 228
-    _RESULTCODE._serialized_end = 276
+    _RESULTCODE._serialized_start = 250
+    _RESULTCODE._serialized_end = 298
     _PROPOSAL._serialized_start = 50
     _PROPOSAL._serialized_end = 75
     _IDREQUESTRESPONSE._serialized_start = 77
     _IDREQUESTRESPONSE._serialized_end = 149
-    _EMPTY._serialized_start = 151
-    _EMPTY._serialized_end = 158
-    _ENTRY._serialized_start = 160
-    _ENTRY._serialized_end = 195
-    _RAFTRESPONSE._serialized_start = 197
-    _RAFTRESPONSE._serialized_end = 226
-    _RAFTSERVICE._serialized_start = 279
-    _RAFTSERVICE._serialized_end = 487
+    _REQUESTIDARGS._serialized_start = 151
+    _REQUESTIDARGS._serialized_end = 180
+    _ENTRY._serialized_start = 182
+    _ENTRY._serialized_end = 217
+    _RAFTRESPONSE._serialized_start = 219
+    _RAFTRESPONSE._serialized_end = 248
+    _RAFTSERVICE._serialized_start = 301
+    _RAFTSERVICE._serialized_end = 517
 # @@protoc_insertion_point(module_scope)

--- a/riteraft/protos/raft_service_pb2.pyi
+++ b/riteraft/protos/raft_service_pb2.pyi
@@ -8,23 +8,22 @@ from google.protobuf import message as _message
 from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
 
 DESCRIPTOR: _descriptor.FileDescriptor
-Error: ResultCode
+
+class ResultCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = []
+    Ok: _ClassVar[ResultCode]
+    Error: _ClassVar[ResultCode]
+    WrongLeader: _ClassVar[ResultCode]
+
 Ok: ResultCode
+Error: ResultCode
 WrongLeader: ResultCode
 
-class Empty(_message.Message):
-    __slots__ = []
-    def __init__(self) -> None: ...
-
-class Entry(_message.Message):
-    __slots__ = ["key", "value"]
-    KEY_FIELD_NUMBER: _ClassVar[int]
-    VALUE_FIELD_NUMBER: _ClassVar[int]
-    key: int
-    value: str
-    def __init__(
-        self, key: _Optional[int] = ..., value: _Optional[str] = ...
-    ) -> None: ...
+class Proposal(_message.Message):
+    __slots__ = ["inner"]
+    INNER_FIELD_NUMBER: _ClassVar[int]
+    inner: bytes
+    def __init__(self, inner: _Optional[bytes] = ...) -> None: ...
 
 class IdRequestResponse(_message.Message):
     __slots__ = ["code", "data"]
@@ -38,17 +37,24 @@ class IdRequestResponse(_message.Message):
         data: _Optional[bytes] = ...,
     ) -> None: ...
 
-class Proposal(_message.Message):
-    __slots__ = ["inner"]
-    INNER_FIELD_NUMBER: _ClassVar[int]
-    inner: bytes
-    def __init__(self, inner: _Optional[bytes] = ...) -> None: ...
+class RequestIdArgs(_message.Message):
+    __slots__ = ["addr"]
+    ADDR_FIELD_NUMBER: _ClassVar[int]
+    addr: str
+    def __init__(self, addr: _Optional[str] = ...) -> None: ...
+
+class Entry(_message.Message):
+    __slots__ = ["key", "value"]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: int
+    value: str
+    def __init__(
+        self, key: _Optional[int] = ..., value: _Optional[str] = ...
+    ) -> None: ...
 
 class RaftResponse(_message.Message):
     __slots__ = ["inner"]
     INNER_FIELD_NUMBER: _ClassVar[int]
     inner: bytes
     def __init__(self, inner: _Optional[bytes] = ...) -> None: ...
-
-class ResultCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
-    __slots__ = []

--- a/riteraft/protos/raft_service_pb2_grpc.py
+++ b/riteraft/protos/raft_service_pb2_grpc.py
@@ -18,7 +18,7 @@ class RaftServiceStub(object):
         """
         self.RequestId = channel.unary_unary(
             "/raftservice.RaftService/RequestId",
-            request_serializer=raft__service__pb2.Empty.SerializeToString,
+            request_serializer=raft__service__pb2.RequestIdArgs.SerializeToString,
             response_deserializer=raft__service__pb2.IdRequestResponse.FromString,
         )
         self.ChangeConfig = channel.unary_unary(
@@ -59,7 +59,7 @@ def add_RaftServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
         "RequestId": grpc.unary_unary_rpc_method_handler(
             servicer.RequestId,
-            request_deserializer=raft__service__pb2.Empty.FromString,
+            request_deserializer=raft__service__pb2.RequestIdArgs.FromString,
             response_serializer=raft__service__pb2.IdRequestResponse.SerializeToString,
         ),
         "ChangeConfig": grpc.unary_unary_rpc_method_handler(
@@ -100,7 +100,7 @@ class RaftService(object):
             request,
             target,
             "/raftservice.RaftService/RequestId",
-            raft__service__pb2.Empty.SerializeToString,
+            raft__service__pb2.RequestIdArgs.SerializeToString,
             raft__service__pb2.IdRequestResponse.FromString,
             options,
             channel_credentials,

--- a/riteraft/raft_client.py
+++ b/riteraft/raft_client.py
@@ -40,9 +40,9 @@ class RaftClient:
             return await asyncio.wait_for(stub.SendMessage(request), timeout)
 
     async def request_id(
-        self, timeout: float = 5.0
+        self, addr: SocketAddr, timeout: float = 5.0
     ) -> raft_service_pb2.IdRequestResponse:
-        request = raft_service_pb2.Empty()
+        request = raft_service_pb2.RequestIdArgs(addr=str(addr))
 
         async with self.__create_channel() as channel:
             stub = raft_service_pb2_grpc.RaftServiceStub(channel)

--- a/riteraft/raft_facade.py
+++ b/riteraft/raft_facade.py
@@ -54,7 +54,7 @@ class RaftClusterFacade:
 
         while not leader_addr:
             client = RaftClient(peer_addr)
-            resp = await client.request_id()
+            resp = await client.request_id(self.addr)
 
             match resp.code:
                 case raft_service_pb2.Ok:

--- a/riteraft/raft_facade.py
+++ b/riteraft/raft_facade.py
@@ -59,10 +59,10 @@ class RaftClusterFacade:
             match resp.code:
                 case raft_service_pb2.Ok:
                     leader_addr = peer_addr
-                    leader_id, node_id = pickle.loads(resp.data)
+                    leader_id, node_id, peer_addrs = pickle.loads(resp.data)
                     break
                 case raft_service_pb2.WrongLeader:
-                    _, peer_addr = pickle.loads(resp.data)
+                    _, peer_addr, _ = pickle.loads(resp.data)
                     logging.info(f"Wrong leader, retrying with leader at {peer_addr}")
                     continue
                 case raft_service_pb2.Error:
@@ -73,6 +73,10 @@ class RaftClusterFacade:
 
         # 2. Run server and node to prepare for joining
         raft_node = RaftNode.new_follower(self.chan, node_id, self.fsm, self.logger)
+        raft_node.peers = {
+            node_id: RaftClient(addr) for node_id, addr in peer_addrs.items()
+        }
+
         raft_node.peers[leader_id] = client
         _ = asyncio.create_task(RaftServer(self.addr, self.chan).run())
         raft_node_handle = asyncio.create_task(raft_node.run())

--- a/riteraft/raft_node.py
+++ b/riteraft/raft_node.py
@@ -358,8 +358,7 @@ class RaftNode:
 
             elif isinstance(message, MessageRaft):
                 msg = MessageAdapter.from_pb(message.msg)
-
-                logging.debug(f"Raft message: to={self.id()} from={msg.get_from()}")
+                logging.debug(f"Received Raft message from {msg.get_from()}")
 
                 try:
                     self.raw_node.step(msg)

--- a/riteraft/raft_node.py
+++ b/riteraft/raft_node.py
@@ -147,7 +147,7 @@ class RaftNode:
         return self.id() == self.leader()
 
     def peer_addrs(self) -> Dict[int, str]:
-        return {k: str(v.addr) for k, v in self.peers.items()}
+        return {k: str(v.addr) for k, v in self.peers.items() if v is not None}
 
     def reserve_next_peer_id(self) -> int:
         """
@@ -349,7 +349,9 @@ class RaftNode:
                     await self.send_wrong_leader(message.chan)
                 else:
                     await message.chan.put(
-                        RaftRespIdReserved(self.reserve_next_peer_id())
+                        RaftRespIdReserved(
+                            self.reserve_next_peer_id(), self.peer_addrs()
+                        )
                     )
 
             elif isinstance(message, MessageRaft):

--- a/riteraft/raft_node.py
+++ b/riteraft/raft_node.py
@@ -350,7 +350,9 @@ class RaftNode:
                 else:
                     await message.chan.put(
                         RaftRespIdReserved(
-                            self.reserve_next_peer_id(), self.peer_addrs()
+                            leader_id=self.leader(),
+                            peer_addrs=self.peer_addrs(),
+                            reserved_id=self.reserve_next_peer_id(),
                         )
                     )
 

--- a/riteraft/raft_node.py
+++ b/riteraft/raft_node.py
@@ -182,14 +182,14 @@ class RaftNode:
     async def send_wrong_leader(self, channel: Queue) -> None:
         assert self.leader() in self.peers, "Leader can't be an empty node!"
 
-        raft_response = RaftRespWrongLeader(
-            leader_id=self.leader(),
-            leader_addr=str(self.peers[self.leader()].addr),
-        )
-
         try:
             # TODO handle error here
-            await channel.put(raft_response)
+            await channel.put(
+                RaftRespWrongLeader(
+                    leader_id=self.leader(),
+                    leader_addr=str(self.peers[self.leader()].addr),
+                )
+            )
         except Exception:
             pass
 
@@ -324,7 +324,7 @@ class RaftNode:
                 if not self.is_leader():
                     # wrong leader send client cluster data
                     # TODO: retry strategy in case of failure
-                    await self.send_wrong_leader(channel=message.chan)
+                    await self.send_wrong_leader(message.chan)
                 else:
                     # leader assign new id to peer
                     logging.debug(f"Received request from: {change.get_node_id()}")
@@ -351,8 +351,8 @@ class RaftNode:
                     await message.chan.put(
                         RaftRespIdReserved(
                             leader_id=self.leader(),
-                            peer_addrs=self.peer_addrs(),
                             reserved_id=self.reserve_next_peer_id(),
+                            peer_addrs=self.peer_addrs(),
                         )
                     )
 

--- a/riteraft/raft_service.py
+++ b/riteraft/raft_service.py
@@ -43,12 +43,13 @@ class RaftService:
                 data=pickle.dumps(tuple([leader_id, leader_addr, None])),
             )
         elif isinstance(response, RaftRespIdReserved):
-            id = response.id
+            reserved_id = response.reserved_id
             peer_addrs = response.peer_addrs
+            leader_id = response.leader_id
 
             return raft_service_pb2.IdRequestResponse(
                 code=raft_service_pb2.Ok,
-                data=pickle.dumps(tuple([1, id, peer_addrs])),
+                data=pickle.dumps(tuple([leader_id, reserved_id, peer_addrs])),
             )
         else:
             assert False, "Unreachable"

--- a/riteraft/raft_service.py
+++ b/riteraft/raft_service.py
@@ -23,12 +23,13 @@ class RaftService:
         self.sender = sender
 
     async def RequestId(
-        self, request: raft_service_pb2.Empty, context: grpc.aio.ServicerContext
+        self, request: raft_service_pb2.RequestIdArgs, context: grpc.aio.ServicerContext
     ) -> raft_service_pb2.IdRequestResponse:
         chan = Queue()
+        addr = request.addr
 
         try:
-            await self.sender.put(MessageRequestId(chan))
+            await self.sender.put(MessageRequestId(addr, chan))
         except Exception:
             pass
 

--- a/riteraft/raft_service.py
+++ b/riteraft/raft_service.py
@@ -40,14 +40,15 @@ class RaftService:
 
             return raft_service_pb2.IdRequestResponse(
                 code=raft_service_pb2.WrongLeader,
-                data=pickle.dumps(tuple([leader_id, leader_addr])),
+                data=pickle.dumps(tuple([leader_id, leader_addr, None])),
             )
         elif isinstance(response, RaftRespIdReserved):
             id = response.id
+            peer_addrs = response.peer_addrs
 
             return raft_service_pb2.IdRequestResponse(
                 code=raft_service_pb2.Ok,
-                data=pickle.dumps(tuple([1, id])),
+                data=pickle.dumps(tuple([1, id, peer_addrs])),
             )
         else:
             assert False, "Unreachable"


### PR DESCRIPTION
<img width="2672" alt="스크린샷 2023-07-21 오후 2 31 31" src="https://github.com/lablup/riteraft-py/assets/18283033/f12a7ca5-253c-4b77-b4c6-f93f6763ff3e">

I think the bug is an issue that occurred because the nodes that joined later could not access the clients of the previous nodes only except for the leader node.

In the 3-node example, the third joined node knows about `RaftClient` of node 1 through `RequestId`, but doesn't know `RaftClient` of node 2.

I checked the leader election occurs successfully when the third node knows the `RaftClient` of the second node.

